### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Prettier Markdown plugin to prevent inserting spaces between Chinese or Japanese & latin latters",
   "main": "dist/main.js",
   "repository": "https://github.com/tats-u/prettier-plugin-md-nocjsp",
+  "homepage": "https://github.com/tats-u/prettier-plugin-md-nocjsp#readme",
+  "bugs": {
+    "url": "https://github.com/tats-u/prettier-plugin-md-nocjsp/issues"
+  },
   "author": "Tatsunori Uchino",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary
- add npm homepage metadata pointing to the README
- add bugs.url metadata pointing to the GitHub issue tracker

## Verification
- Node metadata assertion confirms homepage and bugs.url values
- npm pack --dry-run --ignore-scripts --json includes package.json
- git diff --check passes with only the existing Windows line-ending warning

Note: npm run build currently fails in this checkout because Rollup cannot resolve an existing Prettier internal path. This PR only changes npm package support metadata and leaves runtime code, dependencies, lockfiles, and version fields unchanged.